### PR TITLE
Added log functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ cogs/ipc_server.py
 cogs/itdt.py
 cogs/join.i18n.json
 cogs/join.py
-cogs/log.py
 cogs/nevnap.py
 cogs/poll.py
 cogs/raid.py

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -15,7 +15,7 @@ class Basic(commands.Cog):
 	async def ping(self, ctx: main.Context):
 		# Database ping calculation
 		database_start = perf_counter()
-		await self.client.db.execute("SELECT guild_id FROM guilds WHERE guild_id = $1", ctx.guild.id)
+		await self.client.db.execute("SELECT 1")
 		database = perf_counter() - database_start
 
 		await ctx.send("ping", latency=float(self.client.latency), db=float(database))

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -244,8 +244,8 @@ class EconomyHelper:
 				'UPDATE economy SET bank = $1 WHERE user_id = $2 AND guild_id = $3', amount, user_id, guild_id
 				)
 
-# noinspection PyTypeChecker
 @app_commands.guild_only()
+@commands.guild_only()
 class Economy(commands.GroupCog, group_name="economy"):
 	def __init__(self, client):
 		self.client: MyClient = client

--- a/cogs/log.py
+++ b/cogs/log.py
@@ -1,0 +1,153 @@
+import sys
+
+from discord import app_commands
+
+from helpers import *
+from main import MyClient, Context
+
+class LogCommands(commands.GroupCog, name="log"):
+	def __init__(self, client: MyClient) -> None:
+		self.client = client
+
+	@commands.hybrid_group(name="log", fallback="log-specs_fallback", description="log-specs_description")
+	@commands.has_permissions(manage_guild=True)
+	@app_commands.checks.has_permissions(manage_guild=True)
+	async def log_toggle(self, ctx: Context, state: Literal["on", "off"] = "on", channel: discord.TextChannel = None):
+		is_on = state == "on"
+		if is_on:
+			if not channel:
+				raise commands.MissingRequiredArgument(ctx.command.params["channel"])
+			webhook = discord.utils.get(
+				await channel.webhooks(), name=f"{ctx.me.display_name} - Log"
+			) or await channel.create_webhook(
+				name=f"{ctx.me.display_name} - Log", avatar=await ctx.me.avatar.read()
+			)
+		else:
+			await self.client.db.execute("UPDATE log SET is_on = FALSE WHERE guild_id = $1", ctx.guild.id)
+			await ctx.send("log.toggle.off")
+			return
+
+		await self.client.db.execute(
+			"INSERT INTO log (guild_id, webhook, channel, is_on) VALUES ($1, $2, $3, $4)"
+			" ON CONFLICT (guild_id) DO UPDATE"
+			" SET webhook = excluded.webhook, channel = excluded.channel, is_on = excluded.is_on", ctx.guild.id,
+			webhook.url, channel.id, is_on
+		)
+		await ctx.send(content="log.toggle.on")
+
+	@log_toggle.group(name="module")
+	async def log_module(self, ctx: Context):
+		...
+
+	@log_module.command(name="add")
+	async def log_module_add(self, ctx: Context, module: str):
+		if module == "all":
+			await self.client.db.execute(
+				"UPDATE log SET modules = DEFAULT WHERE guild_id = $1", ctx.guild.id
+			)
+		else:
+			await self.client.db.execute(
+				"UPDATE log SET modules = array_append(modules, $1) WHERE guild_id = $2",
+				module, ctx.guild.id
+			)
+
+		await ctx.send("log.module.add")
+
+	@log_module.command(name="remove")
+	async def log_module_remove(self, ctx: Context, module: str):
+		if module == "all":
+			await self.client.db.execute(
+				"UPDATE log SET modules = ARRAY[] WHERE guild_id = $1", ctx.guild.id
+			)
+		else:
+			await self.client.db.execute(
+				"UPDATE log SET modules = array_remove(modules, $1) WHERE guild_id = $2",
+				module, ctx.guild.id
+			)
+
+		await ctx.send("log.module.add")
+
+class LogListeners(commands.Cog):
+	def __init__(self, client: MyClient) -> None:
+		self.client = client
+
+	# TODO:
+	# 'on_automod_rule_create', 'on_automod_rule_update', 'on_automod_rule_delete', 'on_automod_action',
+	# 'on_guild_channel_delete', 'on_guild_channel_create', 'on_guild_channel_update', 'on_guild_channel_pins_update',
+	# 'on_guild_update', 'on_guild_emojis_update', 'on_guild_stickers_update', 'on_invite_create', 'on_invite_delete',
+	# 'on_guild_integrations_update', 'on_webhooks_update', 'on_raw_integration_delete', 'on_member_join',
+	# 'on_member_remove', 'on_member_update', 'on_member_ban', 'on_member_ban', 'on_member_unban', 'on_message_edit',
+	# 'on_message_delete', 'on_bulk_message_delete', 'on_poll_vote_add', 'on_poll_vote_remove', 'on_reaction_add',
+	# 'on_reaction_remove', 'on_reaction_clear', 'on_reaction_clear_emoji', 'on_guild_role_create',
+	# 'on_guild_role_delete', 'on_scheduled_event_create', 'on_scheduled_event_delete', 'on_scheduled_event_update',
+	# 'on_soundboard_sound_create', 'on_soundboard_sound_delete', 'on_soundboard_sound_update',
+	# 'on_stage_instance_create', 'on_stage_instance_delete', 'on_stage_instance_update', 'on_thread_create',
+	# 'on_thread_join', 'on_thread_update', 'on_thread_remove', 'on_thread_delete', 'on_thread_member_join',
+	# 'on_thread_member_remove', 'on_voice_state_update'
+
+	# DONE:
+
+	async def get_webhook(self, guild_id: int) -> Optional[discord.Webhook]:
+		webhook = await self.client.db.fetchval("SELECT webhook FROM log WHERE guild_id = $1", guild_id)
+		if not webhook:
+			return None
+		return discord.Webhook.from_url(webhook, client=self.client)
+
+	async def send_webhook(self, guild_id: int, key: Optional[str] = None, **kwargs):
+		if not self.log_check(guild_id):
+			return
+
+		if not key:
+			# automatically retreive the name of the function that calls this function and use it as the key
+			key = f"log.{sys._getframe(1).f_code.co_name}"  # type: ignore
+
+		webhook = await self.get_webhook(guild_id)
+		if not webhook:
+			return
+
+		custom_response = CustomResponse(self.client)
+		message: dict | str = await custom_response.get_message(key, self.client.get_guild(guild_id), **kwargs)
+		if isinstance(message, dict):
+			message.pop("delete_after", None)
+			message.pop("ephemeral", None)
+			await webhook.send(**message)
+		else:
+			await webhook.send(content=message)
+
+	@overload
+	async def log_check(self, guild: int):
+		...
+
+	@overload
+	async def log_check(self, guild: discord.Guild):
+		...
+
+	async def log_check(self, guild: Union[int, discord.Guild]):
+		if isinstance(guild, int):
+			guild_id = guild
+		elif isinstance(guild, discord.Guild):
+			guild_id = guild.id
+		return self.client.db.fetchval(
+			f"SELECT is_on FROM log WHERE guild_id = $1 AND {sys._getframe(1).f_code.co_name} IN modules", # type: ignore
+			guild_id
+		)
+
+	@commands.Cog.listener()
+	async def on_automod_rule_create(self, rule: discord.AutoModRule):
+		await self.send_webhook(rule.guild.id, rule=rule)
+
+	@commands.Cog.listener()
+	async def on_automod_rule_update(self, rule: discord.AutoModRule):
+		await self.send_webhook(rule.guild.id, rule=rule)
+
+	@commands.Cog.listener()
+	async def on_message_delete(self, message: discord.Message):
+		await self.send_webhook(message.guild.id, message=message)
+
+	@commands.Cog.listener()
+	async def on_message_edit(self, before: discord.Message, after: discord.Message):
+		await self.send_webhook(before.guild.id, before=before, after=after)
+
+async def setup(client: MyClient) -> None:
+	await client.add_cog(LogCommands(client))
+	await client.add_cog(LogListeners(client))

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Self
+from typing import Self
 
 import asyncpg
 import discord
@@ -9,6 +9,7 @@ from discord.ext import commands, tasks
 import main
 from helpers import *
 from main import MyClient
+from copy import deepcopy
 
 class CaseType(Enum):
 	WARN = 1
@@ -18,43 +19,40 @@ class CaseType(Enum):
 
 class Case:
 	def __init__(
-		self, _type: CaseType, _id: int, guild: discord.Guild, user: Union[discord.Member, discord.User],
-		moderator: discord.User, created: datetime.datetime = None, reason: str = None,
-		expires: datetime.datetime = None, message: str = None
+		self, _type: CaseType, _id: int, guild: discord.Guild, user: discord.Member | discord.User,
+		moderator: discord.User, created: datetime.datetime | None = None, reason: str | None = None,
+		expires: datetime.datetime | None = None, message: str | None = None
 	):
-		self.type = _type
-		self.id = _id
-		self._guild = guild
-		self._user = user
-		self._reason = reason
-		self._moderator = moderator
-		self.expires = expires
-		self.message = message
-		self.length = discord.utils.format_dt(self.expires, "R") if self.expires else "-"
-		self._created = created or datetime.datetime.now()
-
-	def __str__(self):
-		return self.reason
+		self.type: CaseType = _type
+		self.id: int = _id
+		self._guild: discord.Guild = guild
+		self._user: discord.Member | discord.User = user
+		self._reason: str | None = reason
+		self._moderator: discord.User = moderator
+		self.expires: datetime.datetime | None = expires
+		self.message: str | None = message
+		self.length: str | None = discord.utils.format_dt(self.expires, "R") if self.expires else self.expires
+		self._created: datetime.datetime = created or datetime.datetime.now()
 
 	def __repr__(self):
 		return f'Case(type={self.type} user={self._user} reason={self.reason} moderator={self._moderator} duration={self.expires} message={self.message} id={self.id})'
 
-	def __eq__(self, other: Self):
+	def __eq__(self, other):
 		return self.id == other.id
 
-	def __ne__(self, other: Self):
+	def __ne__(self, other):
 		return self.id != other.id
 
-	def __lt__(self, other: Self):
+	def __lt__(self, other):
 		return self.expires < other.expires
 
-	def __le__(self, other: Self):
+	def __le__(self, other):
 		return self.expires <= other.expires
 
-	def __gt__(self, other: Self):
+	def __gt__(self, other):
 		return self.expires > other.expires
 
-	def __ge__(self, other: Self):
+	def __ge__(self, other):
 		return self.expires >= other.expires
 
 	def __int__(self):
@@ -98,8 +96,8 @@ class Case:
 
 	@classmethod
 	async def from_user(
-		cls, db: asyncpg.Pool, user: Union[discord.Member, discord.User], client: discord.Client, guild: discord.Guild,
-		limit: int = None, get_type: bool = True
+		cls, db: asyncpg.Pool, user: discord.Member | discord.User, client: discord.Client, guild: discord.Guild,
+		limit: int | None = None, get_type: bool = True
 	) -> list[Self]:
 		"""Generate a list of `Case`s from a user.
 
@@ -127,7 +125,7 @@ class Case:
 
 	@classmethod
 	async def from_moderator(
-		cls, db: asyncpg.Pool, moderator: discord.User, client: discord.Client, guild: discord.Guild, limit: int = None
+		cls, db: asyncpg.Pool, moderator: discord.User, client: discord.Client, guild: discord.Guild, limit: int | None = None
 	) -> list[Self]:
 		"""Generate a list of `Case`s given by a moderator.
 
@@ -154,7 +152,7 @@ class Case:
 	@classmethod
 	async def from_id(
 		cls, db: asyncpg.Pool, client: discord.Client, guild: discord.Guild, case_id: int, get_type: bool = False
-	) -> Optional[Self]:
+	) -> Self | None:
 		"""Get a `Case` from an ID.
 
 		Parameters
@@ -182,7 +180,7 @@ class Case:
 
 	@classmethod
 	async def from_db(
-		cls, db: asyncpg.Pool, client: discord.Client, guild: discord.Guild = None, *, limit: int = None,
+		cls, db: asyncpg.Pool, client: discord.Client, guild: discord.Guild | None = None, *, limit: int | None = None,
 		get_type: bool = False, **filters: Any
 	) -> list[Any]:
 		"""
@@ -220,14 +218,14 @@ class Case:
 			case_class = case_mapping.get(base_case.type, cls)
 			as_dict = base_case.to_dict()
 			if as_dict.get("_type") is None:
-				cases.append(cls(**as_dict))
+				cases.append(cls(**as_dict))  # type: ignore
 			else:
 				as_dict.pop("_type", None)
 				cases.append(case_class(**as_dict))
 		return cases
 
 	def to_dict(self) -> dict[
-		str, str | None | datetime.datetime | discord.User | int | discord.Message | discord.Member]:
+		str, CaseType | int | discord.Guild | discord.Member | discord.User | str | datetime.datetime | None]:
 		"""Convert the `Case` to a dictionary."""
 		return { "_type": self.type, "_id": self.id, "guild": self._guild, "user": self._user,
 		         "moderator": self._moderator, "reason": self.reason, "expires": self.expires,
@@ -253,6 +251,9 @@ class Case:
 		db: `asyncpg.Pool`
 			The database connection pool.
 		"""
+		if not self._user in self._guild.members:
+			return
+
 		await self.before_deletion()
 		await db.execute("DELETE FROM cases WHERE case_id = $1", self.id)
 		await self.after_deletion()
@@ -265,7 +266,7 @@ class Case:
 		"""An overrideable method that is called after a case is created. The default implementation does nothing."""
 		pass
 
-	async def create(self, db: asyncpg.Pool) -> Self:
+	async def create(self, db: asyncpg.Pool) -> Self | None:
 		"""Create the case in the database.
 
 		Parameters
@@ -278,6 +279,9 @@ class Case:
 		`Case`
 			The created case.
 		"""
+		if not self._user in self._guild.members:
+			return None
+
 		await self.before_creation()
 		await db.execute(
 			"INSERT INTO cases (type, guild_id, case_id, user_id, moderator_id, reason, expires, message) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
@@ -309,10 +313,7 @@ class Case:
 
 	def copy(self) -> Self:
 		"""Copy the case."""
-		return Case(
-			self.type, self.id, self._guild, self._user, self._moderator, self._created, self.reason, self.expires,
-			self.message
-		)
+		return deepcopy(self)
 
 	@property
 	def created(self) -> FormatDateTime:
@@ -320,8 +321,8 @@ class Case:
 		return FormatDateTime(self._created, "R")
 
 	@property
-	def reason(self) -> str:
-		return self._reason or "-"
+	def reason(self) -> str | None:
+		return self._reason
 
 	@reason.setter
 	def reason(self, value: str) -> None:
@@ -333,7 +334,7 @@ class Case:
 
 	@property
 	def user(self) -> CustomUser:
-		return CustomUser.from_user(self._user)
+		return CustomUser.from_user(self._user) if isinstance(self._user, discord.User) else CustomMember.from_user(self._user)
 
 	@property
 	def moderator(self) -> CustomUser:
@@ -341,8 +342,8 @@ class Case:
 
 class Warn(Case):
 	def __init__(
-		self, _id: int, guild: discord.Guild, user: Union[discord.Member, discord.User], moderator: discord.User,
-		reason: str = None, expires: datetime.datetime = None, message: str = None,
+		self, _id: int, guild: discord.Guild, user: discord.Member | discord.User, moderator: discord.User,
+		reason: str | None = None, expires: datetime.datetime | None = None, message: str | None = None,
 		created: datetime.datetime = datetime.datetime.now()
 	):
 		self._user = user
@@ -351,115 +352,112 @@ class Warn(Case):
 
 	async def after_creation(self) -> None:
 		"""Notifies the user about the warning."""
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		message = await self._custom_response.get_message("mod.warn.notify", self._guild, warn=self)
 
 		try:
-			await self._user.send(**message)
+			if isinstance(message, dict):
+				await self._user.send(**message)
 		except discord.Forbidden:
 			pass
 
 	async def after_deletion(self) -> None:
 		"""Notifies the user about the removal of the warning."""
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		message = await self._custom_response.get_message("mod.warn.unwarned", self._guild, warn=self)
 
 		try:
-			await self._user.send(**message)
+			if isinstance(message, dict):
+				await self._user.send(**message)
 		except discord.Forbidden:
 			pass
 
 class Kick(Case):
 	def __init__(
-		self, _id: int, guild: discord.Guild, user: Union[discord.Member, discord.User], moderator: discord.User,
-		reason: str = None, message: str = None, created: datetime.datetime = datetime.datetime.now(), expires=None
+		self, _id: int, guild: discord.Guild, user: discord.Member | discord.User, moderator: discord.User,
+		reason: str | None = None, message: str | None = None, created: datetime.datetime = datetime.datetime.now(), expires=None
 	):
-		super().__init__(CaseType.KICK, _id, guild, user, moderator, created, reason, message)
+		super().__init__(CaseType.KICK, _id, guild, user, moderator, created, reason, expires, message)
 
 	async def before_creation(self) -> None:
 		"""Notifies the user about the kick."""
-		if not self._user in self._guild.members:
-			return
-
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		message = await self._custom_response.get_message("mod.kick.notify", self._guild, kick=self)
 
 		try:
-			await self._user.send(**message)
+			if isinstance(message, dict):
+				await self._user.send(**message)
 		except discord.Forbidden:
 			pass
 
 	async def after_creation(self) -> None:
 		"""Kicks the user."""
-		if not self._user in self._guild.members:
-			return
-
-		await self._user.kick(reason=f"Kicked by {self._moderator}")
+		if isinstance(self._user, discord.Member):
+			await self._user.kick(reason=f"Kicked by {self._moderator}")
 
 class Mute(Case):
 	def __init__(
-		self, _id: int, guild: discord.Guild, user: Union[discord.Member, discord.User], moderator: discord.User,
-		expires: datetime.datetime, reason: str = None, message: str = None,
+		self, _id: int, guild: discord.Guild, user: discord.Member | discord.User, moderator: discord.User,
+		expires: datetime.datetime, reason: str | None = None, message: str | None = None,
 		created: datetime.datetime = datetime.datetime.now()
 	):
 		super().__init__(CaseType.MUTE, _id, guild, user, moderator, created, reason, expires, message)
 
 	async def before_creation(self) -> None:
 		"""Mutes the user."""
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		reason = await self._custom_response("mod.mute.reason", self._guild, mute=self)
-		await self._user.timeout(self.expires.astimezone(datetime.timezone.utc), reason=reason)
+		if isinstance(self._user, discord.Member) and self.expires is not None:
+			await self._user.timeout(self.expires.astimezone(datetime.timezone.utc), reason=reason if isinstance(reason, str) else None)
 
 	async def after_creation(self) -> None:
 		"""Notifies the user about the mute."""
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		message = await self._custom_response.get_message("mod.mute.notify", self._guild, mute=self)
 
 		try:
-			await self._user.send(**message)
+			if isinstance(message, dict):
+				await self._user.send(**message)
 		except discord.Forbidden:
 			pass
 
 	async def before_deletion(self) -> None:
 		"""Unmutes the user."""
-		as_member = self._guild.get_member(self._user.id)
+		as_member: discord.Member | None = self._guild.get_member(self._user.id)  # type: ignore
 		if not as_member or not as_member.timed_out_until:
 			return
 
-		# TODO: add reason
-		await as_member.edit(timed_out_until=None)
+		await as_member.edit(timed_out_until=None, reason=self.reason)
 
 	async def after_deletion(self) -> None:
 		"""Notifies the user about the unmute."""
-		as_member = self._guild.get_member(self._user.id)
-		if not as_member:
-			return
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
 		message = await self._custom_response.get_message("mod.unmute.notify", self._guild, mute=self)
 
 		try:
-			await self._user.send(**message)
+			if isinstance(message, dict):
+				await self._user.send(**message)
 		except discord.Forbidden:
 			pass
 
 class Ban(Case):
 	def __init__(
-		self, _id: int, guild: discord.Guild, user: Union[discord.Member, discord.User], moderator: discord.User,
-		reason: str = None, expires: datetime.datetime = None, message: str = None,
+		self, _id: int, guild: discord.Guild, user: discord.Member | discord.User, moderator: discord.User,
+		reason: str | None = None, expires: datetime.datetime | None = None, message: str | None = None,
 		created: datetime.datetime = datetime.datetime.now()
 	):
 		super().__init__(CaseType.BAN, _id, guild, user, moderator, created, reason, expires, message)
 
 	async def before_creation(self) -> None:
 		"""Notifies the user about the ban."""
-		if self._guild.get_member(self._user.id):  # to avoid spamming non-members
-			self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
-			message = await self._custom_response.get_message("mod.ban.notify", self._guild, ban=self)
+		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
+		message = await self._custom_response.get_message("mod.ban.notify", self._guild, ban=self)
 
-			try:
+		try:
+			if isinstance(message, dict):
 				await self._user.send(**message)
-			except discord.Forbidden:
-				pass
+		except discord.Forbidden:
+			pass
 
 	async def after_creation(self) -> None:
 		"""Bans the user."""
@@ -474,13 +472,15 @@ class Ban(Case):
 
 	async def after_deletion(self) -> None:
 		"""Notifies the user about the unban."""
-		self._custom_response = custom_response.CustomResponse(MyClient, 'mod')  # type: ignore
-		message = await self._custom_response.get_message("mod.unban.notify", self._guild, ban=self)
+		if self._guild.get_member(self._user.id):  # to avoid spamming non-members
+			self._custom_response = custom_response.CustomResponse(MyClient, 'mod')
+			message = await self._custom_response.get_message("mod.unban.notify", self._guild, ban=self)
 
-		try:
-			await self._user.send(**message)
-		except discord.Forbidden:
-			pass
+			try:
+				if isinstance(message, dict):
+					await self._user.send(**message)
+			except discord.Forbidden:
+				pass
 
 @commands.guild_only()
 @app_commands.guild_only()
@@ -489,7 +489,7 @@ class Moderation(commands.GroupCog, name="mod"):
 		self.client = client
 		self.custom_response = custom_response.CustomResponse(client, 'mod')
 
-	@tasks.loop()
+	@tasks.loop(seconds=5)
 	async def case_removal(self):
 		case_rows = await self.client.db.fetch(
 			"SELECT * FROM cases WHERE expires IS NOT NULL AND expires <= $1", datetime.datetime.now()
@@ -752,7 +752,7 @@ class Cases(commands.Cog):
 
 		# since we need the case's information but we don't want to duplicate db calls,
 		# we check inside the actual command
-		if case.user.id != ctx.author.id and not ctx.author.guild_permissions.moderate_members:
+		if case._user.id != ctx.author.id and not ctx.author.guild_permissions.moderate_members:  # type: ignore
 			raise commands.MissingPermissions(["moderate_members"])
 
 		await ctx.send("mod.info.response", case=case)
@@ -779,7 +779,7 @@ class Cases(commands.Cog):
 		if not case:
 			return await ctx.send("mod.delete.errors.not_found", case_id=case_id)
 
-		match case.type:
+		match case.type:  # type: ignore
 			case CaseType.WARN:
 				case = await Warn.from_id(self.client.db, self.client, ctx.guild, case_id)
 			case CaseType.MUTE:
@@ -789,7 +789,7 @@ class Cases(commands.Cog):
 			case CaseType.BAN:
 				case = await Ban.from_id(self.client.db, self.client, ctx.guild, case_id)
 		case._custom_response = self.custom_response
-		await case.delete(self.client.db)
+		await case.delete(self.client.db)  # type: ignore
 
 		await ctx.send("mod.delete.response", case=case)
 
@@ -820,8 +820,8 @@ class Cases(commands.Cog):
 			case_id = int(case_id)
 		except ValueError:
 			raise commands.BadArgument
-		case = await Case.from_id(self.client.db, self.client, ctx.guild, case_id, get_type=True)
-		if not case:
+		case: Case = await Case.from_id(self.client.db, self.client, ctx.guild, case_id, get_type=True)
+		if case is None:
 			return await ctx.send("mod.edit.errors.not_found", case_id=case_id)
 
 		if value == "expires":
@@ -860,7 +860,10 @@ class Cases(commands.Cog):
 		if user.id != ctx.author.id and not ctx.author.guild_permissions.moderate_members:
 			raise commands.MissingPermissions(["moderate_members"])
 
-		message = await self.custom_response("mod.list.response", ctx, cases=cases)
+		message: dict | str | list | int | float = await self.custom_response.get_message("mod.list.response", ctx, cases=cases)
+		if not isinstance(message, dict):
+			return await ctx.send(content=message)
+
 		embeds: list[discord.Embed] = message.get("embeds")
 		if not cases:
 			if embeds:

--- a/first_time.sql
+++ b/first_time.sql
@@ -176,3 +176,17 @@ create table if not exists closed_beta
 alter table closed_beta
     owner to lumin;
 
+create table if not exists log
+(
+    id       serial,
+    guild_id numeric              not null
+        constraint log_pk
+            unique,
+    is_on    boolean default true not null,
+    webhook  text,
+    channel  numeric
+);
+
+alter table log
+    owner to lumin;
+

--- a/helpers/custom_args.py
+++ b/helpers/custom_args.py
@@ -777,3 +777,159 @@ class CustomBOT:
 	@property
 	def programming_library(self) -> str:
 		return self._data['programming_library']
+
+@dataclass
+class CustomMessage:
+	"""A class that represents a Discord message with useful formatting properties.
+	
+	This class is designed to be used in localization strings and provides
+	easy access to message properties that are commonly used in logs.
+	"""
+	id: int
+	"""Returns the message's ID."""
+	content: str
+	"""Returns the message's content."""
+	_embeds: list[discord.Embed] = field(repr=False)
+	_attachments: list[discord.Attachment] = field(repr=False)
+	_stickers: list[discord.StickerItem] = field(repr=False)
+	_author: CustomMember = field(repr=False)
+	_channel: discord.TextChannel = field(repr=False)
+	_guild: CustomGuild = field(repr=False)
+	_created_at: datetime.datetime = field(repr=False)
+	_edited_at: Optional[datetime.datetime] = field(repr=False)
+	_pinned: bool = field(repr=False)
+	_tts: bool = field(repr=False)
+	_mention_everyone: bool = field(repr=False)
+	_mentions: list[discord.Member] = field(repr=False)
+	_role_mentions: list[discord.Role] = field(repr=False)
+	_channel_mentions: list[discord.TextChannel] = field(repr=False)
+	_reference: Optional[discord.MessageReference] = field(repr=False)
+	_flags: discord.MessageFlags = field(repr=False)
+	_components: list[discord.ui.Item] = field(repr=False)
+	_poll: Optional[discord.Poll] = field(repr=False)
+
+	@classmethod
+	def from_message(cls, message: discord.Message):
+		"""Creates a CustomMessage from a discord.Message object."""
+		return cls(
+			id=message.id,
+			content=message.content,
+			_embeds=message.embeds,
+			_attachments=message.attachments,
+			_stickers=message.stickers,
+			_author=CustomMember.from_user(message.author),
+			_channel=message.channel,
+			_guild=CustomGuild.from_guild(message.guild) if message.guild else None,
+			_created_at=message.created_at,
+			_edited_at=message.edited_at,
+			_pinned=message.pinned,
+			_tts=message.tts,
+			_mention_everyone=message.mention_everyone,
+			_mentions=message.mentions,
+			_role_mentions=message.role_mentions,
+			_channel_mentions=message.channel_mentions,
+			_reference=message.reference,
+			_flags=message.flags,
+			_components=message.components,
+			_poll=message.poll
+		)
+
+	@property
+	def embeds(self) -> int:
+		"""Returns the number of embeds in the message."""
+		return len(self._embeds)
+
+	@property
+	def attachments(self) -> int:
+		"""Returns the number of attachments in the message."""
+		return len(self._attachments)
+
+	@property
+	def stickers(self) -> int:
+		"""Returns the number of stickers in the message."""
+		return len(self._stickers)
+
+	@property
+	def author(self) -> CustomMember:
+		"""Returns the message's author."""
+		return self._author
+
+	@property
+	def channel(self) -> str:
+		"""Returns the message's channel mention."""
+		return self._channel.mention
+
+	@property
+	def guild(self) -> CustomGuild:
+		"""Returns the message's guild."""
+		return self._guild
+
+	@property
+	def created_at(self):
+		"""Returns the date the message was created as a Discord timestamp."""
+		return FormatDateTime(self._created_at, "F")
+
+	created = created_at
+
+	@property
+	def edited_at(self):
+		"""Returns the date the message was edited as a Discord timestamp."""
+		return FormatDateTime(self._edited_at, "F") if self._edited_at else None
+
+	edited = edited_at
+
+	@property
+	def pinned(self) -> bool:
+		"""Returns whether the message is pinned."""
+		return self._pinned
+
+	@property
+	def tts(self) -> bool:
+		"""Returns whether the message is TTS."""
+		return self._tts
+
+	@property
+	def mention_everyone(self) -> bool:
+		"""Returns whether the message mentions everyone."""
+		return self._mention_everyone
+
+	@property
+	def mentions(self) -> int:
+		"""Returns the number of user mentions in the message."""
+		return len(self._mentions)
+
+	@property
+	def role_mentions(self) -> int:
+		"""Returns the number of role mentions in the message."""
+		return len(self._role_mentions)
+
+	@property
+	def channel_mentions(self) -> int:
+		"""Returns the number of channel mentions in the message."""
+		return len(self._channel_mentions)
+
+	@property
+	def reference(self) -> Optional[str]:
+		"""Returns the message's reference if it exists."""
+		return self._reference.message_id if self._reference else None
+
+	@property
+	def flags(self) -> int:
+		"""Returns the message's flags as an integer."""
+		return self._flags.value
+
+	@property
+	def components(self) -> int:
+		"""Returns the number of components in the message."""
+		return len(self._components)
+
+	@property
+	def poll(self) -> bool:
+		"""Returns whether the message has a poll."""
+		return bool(self._poll)
+
+	def __str__(self):
+		return self.content
+
+	def __int__(self):
+		return self.id

--- a/helpers/regex.py
+++ b/helpers/regex.py
@@ -1,1 +1,3 @@
-DISCORD_INVITE = r"(https?:\/\/)?(www\.)?(discord\.(gg|io|me|li)|discordapp\.com\/invite)\/.+[a-z]"
+import re
+
+DISCORD_INVITE = re.compile(r"(https?://)?(www\.)?(discord\.(gg|io|me|li)|discordapp\.com/invite)/.+[a-z]")

--- a/localization/en.l10n.json
+++ b/localization/en.l10n.json
@@ -722,6 +722,30 @@
 			}
 		}
 	},
+	"log": {
+		"on_message_edit": {
+			"content": {
+				"embeds": [
+					{
+						"title": "Message edited",
+						"fields": [
+							{
+								"name": "Content before",
+								"value": "{before}",
+								"inline": false
+							},
+							{
+								"name": "Content after",
+								"value": "{after}",
+								"inline": false
+							}
+						],
+						"color": 6656243
+					}
+				]
+			}
+		}
+	},
 	"ipinfo": {
 		"embeds": [
 			{


### PR DESCRIPTION
This PR introduces the `log.py` module and it's skeleton. It works as follows:

- event listeners check the differences between properties (e.x. `before.content != after.content`)
  - event listener sends the localized message with the webhook - `.send_webhook()`. params are as follows:
      1. the guild ID - used for retreiving the guild's webhook
      2. the event - if we're comparing `before.content` against `after.content`, we'll pass `"content"`. this will mean that the `send_webhook()` method will use the `"log.on_message_edit.content"` key.
      3. the kwargs: in this case, we're saying `before=before.content, after=after.content`, and during localization, `"{before}"` will be replaced with `before.content`, `"{after}"` will be replaced with `after.content`.

# TODO:
in `LogListeners.log_check`, currently, we're only checking for the guild ID - we need to check if the guild actually allows messages from the event!