### PR TITLE
feat: use DEBUG environment variable for client.debug #FM-T6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ DEBUG_TOKEN=your_debug_bot_token
 DB_HOST=localhost_or_ip_address
 DB_PASSWORD=your_database_password
 DB_PORT=your_database_port_REQUIRED
-DEBUG=false
+DEBUG=0|1

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Pulled successfully"
           tmux has-session -t beta 2>/dev/null && tmux kill-session -t beta
           echo "Killed beta"
-          tmux new -d -s beta 'uv run python -OO main.py'
+          tmux new -d -s beta 'uv run main.py'
           tmux set-option -t beta remain-on-exit on
           echo "Bot is running"
           EOF

--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ from core.bot import Bot
 from core.log import logger
 from dotenv import load_dotenv
 
+import logging
+
 try:
 	import uvloop  # type: ignore
 
@@ -28,14 +30,16 @@ async def main(debug) -> None:
 
 	global client
 	client = Bot()
-	client.debug = debug
+	client.debug = debug or bool(int(os.getenv("DEBUG", False)))
 
 	if client.debug:
 		token = os.getenv("DEBUG_TOKEN")
 		logger.info("Running in debug mode")
+		logger.setLevel(logging.DEBUG)
 	else:
 		token = os.getenv("TOKEN")
 		logger.info("Running in production mode")
+		logger.setLevel(logging.INFO)
 
 	if token:
 		await client.start(token)


### PR DESCRIPTION
makes use of the DEBUG value in the `.env` file (`0` or `1`)

overrides command line argument